### PR TITLE
fix([29051365] open AR on browser ios)

### DIFF
--- a/_src/pages/Landing/index.jsx
+++ b/_src/pages/Landing/index.jsx
@@ -50,9 +50,13 @@ const Landing = () => {
     setIsCanGoBack(nativeEvent?.canGoBack);
     if (IS_IOS) {
       const url = nativeEvent?.url;
-      if (url.startsWith('https://seller.medbiz.id/login')) {
-        Linking.openURL(url);
-        webViewRef.current.goBack();
+      if (
+        url.startsWith('https://seller.medbiz.id/login') ||
+        url.startsWith(`${Config.PWA_BASE_URL}/ar`)
+      ) {
+        Linking.openURL(url)
+          .then(() => webViewRef.current.goBack())
+          .catch(() => webViewRef.current.goBack());
       }
     }
   };


### PR DESCRIPTION
Updates:
1. user agent for android and ios
2. open specific url on browser (https://seller.medbiz.id/login)
3. history back webview
4. double backpress to exit
5. deeplink AR open on browser (ios)